### PR TITLE
Feature/cicd delete old jobs

### DIFF
--- a/.github/workflows/deployColl.yml
+++ b/.github/workflows/deployColl.yml
@@ -81,6 +81,14 @@ jobs:
           tag=$(echo ${IMAGE_TAG##*:})
           for cronjob in $(kubectl get cronjobs | awk '{print $1}' | grep -iv name); do kubectl get cronjob ${cronjob} -o json | jq -r '.spec.jobTemplate.spec.template.spec.containers[].image' | cut -d ':' -f2 | while read result; do { [[ ${result} == ${tag} ]] && echo "Deployment ${cronjob} ok"; } || { echo "Deployment ${cronjob} ko" && exit 1; }; done ; done
 
+      - name: Delete old jobs
+        id: delete-jobs
+        env:
+          IMAGE_TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          tag=$(echo ${IMAGE_TAG##*:})
+          kubectl get jobs | grep -i dtd-crawler-scan-manager | awk '{print $1}' | while read job; do kubectl get job -o json ${job} | jq '.spec.template.spec.containers[].image' -r | cut -d ':' -f2 | while read version; do { [[ ${version} != ${tag} ]] && kubectl delete job ${job}; } || { echo "${job} to not be deleted"; }; done ; done
+
       - name: Send SNS notification when the deploy completes in collaudo
         id: sns-success
         if: success()

--- a/.github/workflows/deployColl.yml
+++ b/.github/workflows/deployColl.yml
@@ -87,7 +87,7 @@ jobs:
           IMAGE_TAG: ${{ steps.vars.outputs.tag }}
         run: |
           tag=$(echo ${IMAGE_TAG##*:})
-          kubectl get jobs | grep -i dtd-crawler-scan-manager | awk '{print $1}' | while read job; do kubectl get job -o json ${job} | jq '.spec.template.spec.containers[].image' -r | cut -d ':' -f2 | while read version; do { [[ ${version} != ${tag} ]] && kubectl delete job ${job}; } || { echo "${job} to not be deleted"; }; done ; done
+          kubectl get jobs -n dtd-crawler-coll | grep -i dtd-crawler-scan-manager | awk '{print $1}' | while read job; do kubectl -n dtd-crawler-coll get job -o json ${job} | jq '.spec.template.spec.containers[].image' -r | cut -d ':' -f2 | while read version; do { [[ ${version} != ${tag} ]] && kubectl -n dtd-crawler-coll delete job ${job}; } || { echo "${job} to not be deleted"; }; done ; done
 
       - name: Send SNS notification when the deploy completes in collaudo
         id: sns-success

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -85,7 +85,7 @@ jobs:
           IMAGE_TAG: ${{ steps.vars.outputs.tag }}
         run: |
           tag=$(echo ${IMAGE_TAG##*:})
-          kubectl get jobs | grep -i dtd-crawler-scan-manager | awk '{print $1}' | while read job; do kubectl get job -o json ${job} | jq '.spec.template.spec.containers[].image' -r | cut -d ':' -f2 | while read version; do { [[ ${version} != ${tag} ]] && kubectl delete job ${job}; } || { echo "${job} to not be deleted"; }; done ; done
+          kubectl get jobs -n dtd-crawler-prod | grep -i dtd-crawler-scan-manager | awk '{print $1}' | while read job; do kubectl -n dtd-crawler-prod get job -o json ${job} | jq '.spec.template.spec.containers[].image' -r | cut -d ':' -f2 | while read version; do { [[ ${version} != ${tag} ]] && kubectl -n dtd-crawler-prod delete job ${job}; } || { echo "${job} to not be deleted"; }; done ; done
   
       - name: Send SNS notification when the deploy completes in production
         id: sns-success

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -79,6 +79,14 @@ jobs:
           tag=$(echo ${IMAGE_TAG##*:})
           for cronjob in $(kubectl get cronjobs | awk '{print $1}' | grep -iv name); do kubectl get cronjob ${cronjob} -o json | jq -r '.spec.jobTemplate.spec.template.spec.containers[].image' | cut -d ':' -f2 | while read result; do { [[ ${result} == ${tag} ]] && echo "Deployment ${cronjob} ok"; } || { echo "Deployment ${cronjob} ko" && exit 1; }; done ; done
 
+      - name: Delete old jobs
+        id: delete-jobs
+        env:
+          IMAGE_TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          tag=$(echo ${IMAGE_TAG##*:})
+          kubectl get jobs | grep -i dtd-crawler-scan-manager | awk '{print $1}' | while read job; do kubectl get job -o json ${job} | jq '.spec.template.spec.containers[].image' -r | cut -d ':' -f2 | while read version; do { [[ ${version} != ${tag} ]] && kubectl delete job ${job}; } || { echo "${job} to not be deleted"; }; done ; done
+  
       - name: Send SNS notification when the deploy completes in production
         id: sns-success
         if: success()

--- a/.github/workflows/deployProd.yml
+++ b/.github/workflows/deployProd.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           tag=$(echo ${IMAGE_TAG##*:})
           kubectl get jobs -n dtd-crawler-prod | grep -i dtd-crawler-scan-manager | awk '{print $1}' | while read job; do kubectl -n dtd-crawler-prod get job -o json ${job} | jq '.spec.template.spec.containers[].image' -r | cut -d ':' -f2 | while read version; do { [[ ${version} != ${tag} ]] && kubectl -n dtd-crawler-prod delete job ${job}; } || { echo "${job} to not be deleted"; }; done ; done
-  
+
       - name: Send SNS notification when the deploy completes in production
         id: sns-success
         if: success()


### PR DESCRIPTION
Added a new step that deletes the old jobs with the old image tag so that the new version can go up immediately, to figure out if we should also launch a new job from the new cronjob to start a new scan ASAP.